### PR TITLE
added user binary build path to $PATH

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Bulwark Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Once you are logged in, run this line:
 bash <( wget -qO - https://raw.githubusercontent.com/kewagi/bwk/master/prepare.sh )
 ```
 
-The installer will prepare some things, then open the Raspberry configuration tool _raspi-config_ - change the following settings:
+The installer will prepare some things, then open the Raspberry configuration tool _raspi-config_.  
+Change the following settings:
 
 ```
 * Change your password              1 Change User Password
@@ -87,7 +88,8 @@ The installer will prepare some things, then open the Raspberry configuration to
 * Optional: Set GPU Memory to 16MB  7 Advanced Options -> A3 Memory Split
 ```
 
-Select "Finish" and press Enter, your Raspberry will reboot. Wait for a minute, log into your Raspberry again, then run this command:
+Select "Finish" and press Enter, your Raspberry will reboot.  
+Wait for a minute, log into your Raspberry again, then run this command:
 
 ```
 sudo bash shn.sh

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ You should see a single line containing the IP address of your home node.
 ### Linux
 Open a shell and run the following command:
 ```
-arp -na | grep -i b8:27:eb | head -1 | awk -F ' ' '{print $2}'```
+arp -na | grep -i b8:27:eb | head -1 | awk -F ' ' '{print $2}'
+```
 You should see a single line containing the IP address of your home node.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,78 @@
-# SHN Installer
+# Bulwark Secure Home Node Installer
 
-Log in to your Raspberry Pi via SSH, then run this line:
+## Table of contents
+- [Requirements](#requirements)
+- [Connecting your SHN to your network](#connecting-your-shn-to-your-network)
+  * [Connecting via ethernet](#connecting-via-ethernet)
+  * [Connecting via Wi-fi](#connecting-via-wi-fi)
+    + [Monitor & Keyboard](#monitor---keyboard)
+    + [microSD card reader](#microsd-card-reader)
+- [Finding your SHN on your network](#finding-your-shn-on-your-network)
+  * [Windows](#windows)
+  * [macOS](#macos)
+  * [Linux](#linux)
+- [Installation](#installation)
+
+## Requirements
+To use your secure home node, you need a stable internet connection with a static IP address. To connect your node, you need either a network router with a free RJ-45 port and an ethernet cable or a router running a 2.4Ghz Wi-fi network.
+
+If you want to connect via Wi-fi, you will also need either a monitor that supports HDMI (along with a HDMI cable) and a keyboard, or a microSD card reader that works with your computer.
+
+## Connecting your SHN to your network
+To connect your home node, you have two options: ethernet and Wi-fi.
+
+### Connecting via ethernet
+Simply plug in an ethernet cable running to your router into the Raspberry Pi before you connect the power cable. Once you've done that, proceed to [Finding your SHN on your network](#finding-your-shn-on-your-network).
+
+### Connecting via Wi-fi
+To set up Wi-fi, you can either connect your SHN to a monitor and keyboard or use a microSD card reader.
+
+#### Monitor & Keyboard
+Connect your monitor to the Raspberry Pi with an HDMI cable and plug in a USB keyboard. Connect power to the Raspberry Pi, wait for it to boot up, then log in with the default credentials - user "pi", password "raspberry"
+
+Once you are logged in, run the command
+```
+sudo raspi-config
+```
+You will see a graphical interface. First, select "Network Options", then "Wi-fi". In the following screens, select your country (this is necessary in order to use the correct frequencies), then enter your Wi-fi SSID (it's name) and the password. Once you are done, select "Finish" and restart your Raspberry Pi. Then proceed to [Finding your SHN on your network](#finding-your-shn-on-your-network).
+
+#### microSD card reader
+Put the microSD card from the Raspberry Pi into your card reader and connect it with your computer. In the root directory of the SD card, create a text file called _wpa_supplicant.conf_ and add the following text to it:
+```
+country=YOURCOUNTRYCODE
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev update_config=1
+network={
+       ssid="YOURNETWORKSSID"
+       psk="YOURNETWORKPASSWORD"
+       key_mgmt=WPA-PSK
+    }
+```
+
+Replace _YOURCOUNTRYCODE_ with the [two letter ISO code](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) of your country, _YOURNETWORKSSID_ with the name of your wireless network and _YOURNETWORKPASSWORD_ with the password of your wireless network (the password will be encrypted during the installation). Proceed to [Finding your SHN on your network](#finding-your-shn-on-your-network)
+
+## Finding your SHN on your network
+Next, you need to find the IP address your SHN has been assigned by your router. How you do this depends on your operating system.
+
+### Windows
+Download the [Adafruit Pi Finder](https://github.com/adafruit/Adafruit-Pi-Finder/releases) for Windows and run it. It will detect your Raspberry Pi and allow you to connect by clicking the "Terminal" button. Proceed to [Installation](#installation).
+
+### macOS
+Open Terminal.app and run the following command:
+```
+ping raspberrypi.local -c1 | head -1 | awk -F " " '{print $3}'
+```
+You should see a single line containing the IP address of your home node.
+
+### Linux
+Open a shell and run the following command:
+```
+arp -na | grep -i b8:27:eb | head -1 | awk -F ' ' '{print $2}'```
+You should see a single line containing the IP address of your home node.
+
+## Installation
+Now you're ready to install! Using [Putty](https://www.putty.org/) or a terminal, connect to your SHN using the address you found in the last step and the username "pi" - the default password is "raspberry" - don't worry, we will change this in a bit.
+
+Once you are logged in, run this line:
 
 ```
 bash <( wget -qO - https://raw.githubusercontent.com/kewagi/bwk/master/prepare.sh )
@@ -10,7 +82,6 @@ The installer will prepare some things, then open the Raspberry configuration to
 
 ```
 * Change your password              1 Change User Password
-* Optional: Set up your WiFi        2 Network Options  -> N2 WiFi
 * Expand your filesystem            7 Advanced Options -> A1 Expand Filesystem
 * Optional: Set GPU Memory to 16MB  7 Advanced Options -> A3 Memory Split
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ network={
     }
 ```
 
-Replace _YOURCOUNTRYCODE_ with the [two letter ISO code](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) of your country, _YOURNETWORKSSID_ with the name of your wireless network and _YOURNETWORKPASSWORD_ with the password of your wireless network (the password will be encrypted during the installation). Proceed to [Finding your SHN on your network](#finding-your-shn-on-your-network)
+Replace _YOURCOUNTRYCODE_ with the [two letter ISO code](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) of your country, _YOURNETWORKSSID_ with the name of your wireless network and _YOURNETWORKPASSWORD_ with the password of your wireless network (the password will be encrypted during the installation). Eject the SD card, put it back into your Raspberry Pi and connect the power cable, then proceed to [Finding your SHN on your network](#finding-your-shn-on-your-network)
 
 ## Finding your SHN on your network
 Next, you need to find the IP address your SHN has been assigned by your router. How you do this depends on your operating system.

--- a/prepare.sh
+++ b/prepare.sh
@@ -25,7 +25,6 @@ cat << EOL
 We will now start raspi-config. Please change the following settings:
 
 * Change your password              1 Change User Password
-* Optional: Set up your WiFi        2 Network Options  -> N2 WiFi
 * Expand your filesystem            7 Advanced Options -> A1 Expand Filesystem
 * Optional: Set GPU Memory to 16MB  7 Advanced Options -> A3 Memory Split
 

--- a/shn.sh
+++ b/shn.sh
@@ -77,18 +77,20 @@ sleep 1
 sudo wget https://storage.googleapis.com/golang/go1.9.linux-armv6l.tar.gz
 sudo tar -C /usr/local -xzf go1.9.linux-armv6l.tar.gz
 sudo rm go1.9.linux-armv6l.tar.gz
+sudo mkdir -p /home/bulwark/go/bin
+sudo chown -R bulwark:bulwark /home/bulwark/go
 sleep 1
 # put into global /etc/profile
 export PATH=$PATH:/usr/local/go/bin
 sudo su -c "echo 'PATH=/usr/local/go/bin:$PATH' >> /etc/profile"
+source /etc/profile
 sleep 1
 # put into user's ~/.profile
-export GOPATH=$HOME/go
-echo "" >> /home/pi/.profile
-echo "# Bulwark settings" >> /home/pi/.profile
-sudo sh -c "echo 'GOPATH=$HOME/go' >> /home/pi/.profile"
-source /etc/profile
-source ~/.profile
+export GOPATH=/home/bulwark/go
+export PATH=$PATH:$GOPATH/bin
+echo "" >> /home/bulwark/.profile
+echo "# Bulwark settings" >> /home/bulwark/.profile
+sudo sh -c "echo 'GOPATH=/home/bulwark/go' >> /home/bulwark/.profile"
 sleep 1
 sudo mkdir /home/bulwark/.bulwark
 wget $BOOTSTRAPURL && unzip $BOOTSTRAPARCHIVE -d /home/bulwark/.bulwark/ && rm $BOOTSTRAPARCHIVE

--- a/tor.sh
+++ b/tor.sh
@@ -67,12 +67,14 @@ sleep 1
 sudo wget https://storage.googleapis.com/golang/go1.9.linux-armv6l.tar.gz
 sudo tar -C /usr/local -xzf go1.9.linux-armv6l.tar.gz
 sudo rm go1.9.linux-armv6l.tar.gz
+sudo mkdir -p /home/bulwark/go/bin
 sleep 1
 # put into global /etc/profile
 export PATH=$PATH:/usr/local/go/bin
 sleep 1
 # put into user's ~/.profile
 export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
 source /etc/profile
 source ~/.profile
 sleep 1


### PR DESCRIPTION
when the bwk-dash binary is built it places the binary in the $GOPATH/bin folder for inclusion into the $PATH variable which should be set during installation of Go. I added the mkdir to ensure its there and another export statement for the user's profile.

let me know if I need to change anything.